### PR TITLE
Add option to tell selectize, how many letters you have to type to st…

### DIFF
--- a/client-side/selectize.js
+++ b/client-side/selectize.js
@@ -38,6 +38,8 @@ SelectizeForNette.prototype = {
 
     constructor: SelectizeForNette,
 
+    minSearchLength: 3,
+
     init: function()
     {
         var base = this;
@@ -91,7 +93,7 @@ SelectizeForNette.prototype = {
 
             } else {
                 this.options.load = function(query, callback) {
-                    if (!query.length || query.length < 3) return callback();
+                    if (!query.length || query.length < this.minSearchLength) return callback();
                     $.ajax({
                         url: base.settings.ajaxURL,
                         data: {query: query},

--- a/docs/en/ajax.md
+++ b/docs/en/ajax.md
@@ -46,3 +46,15 @@ with valueField and labelField columns set before. Response from this handler lo
     ...
 }
 ```
+
+## Minimal letters count to start searching:
+
+After typing more than 3 letters, ajax searching call will be triggered. If you want to change default value, 
+just add this line before your selectize() call.
+
+```
+SelectizeForNette.minSearchLength: yourNumber;
+```
+
+
+


### PR DESCRIPTION
**Add option** to tell selectize, **how many letters you have to type to start AJAX request**.

It can be usefull for everyone, because you don't have to override default file.


If you want to change the default value just add this line of code:

`SelectizeForNette.minSearchLength: yourNumber;`