### PR TITLE
FIX: When 'select' mode, setValue was ignored

### DIFF
--- a/src/Selectize.php
+++ b/src/Selectize.php
@@ -240,7 +240,8 @@ class Selectize extends Nette\Forms\Controls\BaseControl
 				->data('entity', $this->entity)
 				->data('options', $this->options)
 				->class(isset($this->options['class']) ? $this->options['class'] : 'selectize' . ' form-control')
-				->addAttributes(parent::getControl()->attrs);
+				->addAttributes(parent::getControl()->attrs)
+                ->setValue($this->selectizeBack);
 		}
 	}
 

--- a/src/Selectize.php
+++ b/src/Selectize.php
@@ -241,7 +241,7 @@ class Selectize extends Nette\Forms\Controls\BaseControl
 				->data('options', $this->options)
 				->class(isset($this->options['class']) ? $this->options['class'] : 'selectize' . ' form-control')
 				->addAttributes(parent::getControl()->attrs)
-                ->setValue($this->selectizeBack);
+                		->setValue($this->selectizeBack);
 		}
 	}
 


### PR DESCRIPTION
Hello,

I have found a bug. Where you are in 'select' mode, calls from setValue() are ignored, because there is missing this one line, which will solve it.